### PR TITLE
chore: promote backend to version 1.0.0

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,5 +7,11 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: https://skreet2k.github.io/charts/
+- name: dev2
+  url: https://skreet2k.github.io/helm-charts/
+releases:
+- chart: dev2/backend
+  version: 1.0.0
+  name: backend
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote backend to version 1.0.0

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
